### PR TITLE
return unicode text to avoid UnicodeDecodeError

### DIFF
--- a/multilingual_tags/models.py
+++ b/multilingual_tags/models.py
@@ -85,7 +85,7 @@ class TaggedItem(models.Model):
     object = generic.GenericForeignKey('content_type', 'object_id')
 
     def __unicode__(self):
-        return '{0}: #{1}'.format(self.object, self.tag)
+        return u'{0}: #{1}'.format(self.object, self.tag)
 
     class Meta:
         unique_together = ('content_type', 'object_id', 'tag')


### PR DESCRIPTION
I get a UnicodeDecodeError in admin change_list when the tagged objects contains special chars.
